### PR TITLE
 ~ simplified the interface so we no longer have to pass option -nproc

### DIFF
--- a/_lessons/python-scatter/04a-multiprocessing.md
+++ b/_lessons/python-scatter/04a-multiprocessing.md
@@ -5,13 +5,9 @@ permalink: /python-scatter/multiprocessing
 chapter: python-scatter
 ---
 
-**Work in progress**
-
 ## Objectives
 
-You will:
-
-* learn how to call a function in parallel using shared memory multiprocessing
+Learn how to call a function in parallel using shared memory multiprocessing.
 
 We'll use the code in directory `multiproc`. Start by
 ```
@@ -20,23 +16,28 @@ cd multiproc
 
 ## Why multiprocessing
 
-Multiprocessing is suitable when you have a large number of tasks to be executed in any order.
+Multiprocessing is suitable when you have:
+
+ * computational resources with many CPU cores. On Mahuika, you can access up to 36 cores (72 multithreads).
+ * a large number of tasks to be executed in any order
 
 ### Pros
 
- * A way to leverage multiple CPU cores for increased performance
- * Can handle different work load
+ * a way to leverage multiple CPU cores for increased performance
+ * can handle different work load
 
 ### Cons
 
- * Processes must typically run on the same node
+ * processes must typically run on the same node
 
 ## Learn the basics 
 
 As an example, we'll assume that you have to apply a very expensive function to a large number of input values:
 ```python
+import time
 def f(x):
-	...          # expensive function
+	# expensive function
+	time.sleep(10)
 	return value
 
 res = [f(x) for x in input_values]
@@ -46,13 +47,14 @@ In its original form, function `f` is called sequentially for each value of `x`.
 import multiprocessing
 
 def f(x):
-	...          # expensive function
+	# expensive function
+	time.sleep(10)
 	return value
 
 pool = multiprocessing.Pool(processes=8)
 res = pool.map(f, input_values)
 ```
-How it works: each input value of array `input_values` is put in a queue and handed over to a worker. There are in this case 8 workers who accomplish the task in parallel. When a worker has finished a task, a new task is assigned until the queue is empty. At which point all the elements of array `res` have been filled.
+How it works: each input value of array `input_values` is put in a queue and handed over to a worker. Here, there are 8 workers who accomplish the task in parallel. When a worker has finished a task, a new task is assigned until the queue is empty. At which point all the elements of array `res` have been filled.
 
 ## Running the scatter code using multiple threads
 
@@ -70,10 +72,10 @@ python scatter.py
 
 ## Exercises
 
-We've created a version of `scatter.py` which takes `-nproc`, the number of processes, as a command line argument.  In this version, the computation of the field values takes place in function 
+We've created a version of `scatter.py` which reads the environment variable `OMP_NUM_THREADS` to set the number of threads.  In this version, the computation of the field values takes place in function 
 ```python
 def  computeField(k):
-	...
+	#...
 ```
 with argument `k` being the flat index into the 2D field arrays representing the incident and scatted fields (i.e. `k = j*nx1 + i`). In our formulation, the field at any location depends only on the values on the domain and obstacle boundaries, not on neighbouring locations. This allows us to compute the scatted and incident fields
 ```python

--- a/_lessons/python-scatter/04a-multiprocessing.md
+++ b/_lessons/python-scatter/04a-multiprocessing.md
@@ -45,7 +45,7 @@ res = [f(x) for x in input_values]
 In its original form, function `f` is called sequentially for each value of `x`. The modified version using 8 processes reads:
 ```python
 import multiprocessing
-
+import time
 def f(x):
 	# expensive function
 	time.sleep(10)


### PR DESCRIPTION
Hi @chrisdjscott,
I changed the code in https://github.com/pletzer/scatter so it no longer takes the -nproc option. Instead the number of threads is taken from the OMP_NUM_THREADS variable. Hence, we can run the code the same way as in the openmp section and we can more easily compare the performance. 