### PR TITLE
Fixed the example code

### DIFF
--- a/_lessons/python-scatter/04b-openmp.md
+++ b/_lessons/python-scatter/04b-openmp.md
@@ -117,7 +117,7 @@ Variable `tot` is special - it has to store the sum across all loop iterations a
 
 ## Exercises
 
- 1. Add OpenMP pragma at line indicated by `// ADD OPENMP PRAGMA HERE` in `src/wave.cpp`
+ 1. Add OpenMP pragma at line indicated by `// ADD OPENMP PRAGMA HERE` in `src/wave.cpp`. Assume that function `computeScatteredWaveElement` is thread-safe.
 
  2. Measure the speedup vs the number of threads (`OMP_NUM_THREADS` values) using problem size `-nx 256 -ny 256 -nc 1024`
 

--- a/_lessons/python-scatter/04b-openmp.md
+++ b/_lessons/python-scatter/04b-openmp.md
@@ -93,11 +93,11 @@ In the following, we parallelise a loop computing the total contour length:
  */
 double getContourLength(const int nc, const double xc[], const double yc[]) {
     double tot = 0.0;
-#pragma omp parallel for default(none) shared(nc, xc, yc) reduction(+:tot)
+#pragma omp parallel for default(none) shared(xc, yc) reduction(+:tot)
     for (int i = 0; i < nc - 1; ++i) {
         // dx and dy are declared inside the loop and thus private 
-        double dx = xc[i + 1] - x[i];
-        double dy = yc[i + 1] - y[i];
+        double dx = xc[i + 1] - xc[i];
+        double dy = yc[i + 1] - yc[i];
         tot += std::sqrt(dx*dx + dy*dy);
     }
     return tot;

--- a/_lessons/python-scatter/04b-openmp.md
+++ b/_lessons/python-scatter/04b-openmp.md
@@ -75,7 +75,7 @@ There are various ways to distribute workloads for parallel execution, the most 
 
 [![example-mpi-gather](images/example_omp_threads.png)](images/example_omp_threads.png)
 
-The application always starts in serial mode on a single thread (single arrow at the top). When requested, multiple threads are created/spawned (multiple arrays at the top). In this particular case, the number of threads is 3 (coloured boxes), and each thread performs three iterations (9 iterations altogether). Results are stored in separate elements of array `a` for each loop index `i`, so we do not create a race condition when the loop is executed in parallel. The program then resumes running on a single thread (single arrow at the bottom).
+The application always starts in serial mode on a single thread (single arrow at the top). When requested, multiple threads are created/spawned (multiple arrows at the top). In this particular case, the number of threads is 3 (coloured boxes), and each thread performs three iterations (9 iterations altogether). Results are stored in separate elements of array `a` for each loop index `i`, so we do not create a race condition when the loop is executed in parallel. The program then resumes running on a single thread (single arrow at the bottom).
 
 ### Data handling
 Because OpenMP is based on the shared memory programming model, most variables are shared by default. Other variables like loop index are meant to be private. By private we mean that the variable can take a different value for each thread. The programmer determines which variables are private and which are shared.
@@ -91,7 +91,6 @@ In the following, we parallelise a loop computing the total contour length:
  * @param xc x points (last point is same as first point)
  * @param yc y points (yc[nc-1] == yc[0])
  */
-extern "C"
 double getContourLength(const int nc, const double xc[], const double yc[]) {
     double tot = 0.0;
 #pragma omp parallel for default(none) shared(nc, xc, yc) reduction(+:tot)
@@ -101,6 +100,7 @@ double getContourLength(const int nc, const double xc[], const double yc[]) {
         double dy = yc[i + 1] - y[i];
         tot += std::sqrt(dx*dx + dy*dy);
     }
+    return tot;
 }
 ```
 With the `parallel` statement we ask the compiler to spawn threads. The number of threads can be set using environment variable `OMP_NUM_THREADS`, which can be anything between 1 and the number of cores on a node, e.g., `export OMP_NUM_THREADS=36`.
@@ -109,7 +109,7 @@ The `for` construct specifies that we want to parallelise the `for` loop that im
 
 It is good practice to always use the `default(none)` clause, which forces us to declare the `shared` or `private` status of each variable defined _above_ the parallel region. Variables that are defined _inside_ the parallel region, such as loop index variable `i` or helper variables `dx` and `dy`, are automatically private. Each thread gets its own copy of `i`, `dx` and `dy`.
 
-It is generally good practice to define local variables such as `dx` inside the loop where possible. This will make your program easier to read and maintain, and you don't have to worry about creating race conditions by erroneously sharing a variable between threads. If you still need to declare, e.g., `myvariable` outside the loop, add the clause `private(myvariable)` to the OpenMP pragma.
+It is generally good practice to define local variables such as `dx` inside the loop where possible. This will make your program easier to read and maintain and you won't have to worry about creating race conditions by erroneously sharing a variable between threads. If you still need to declare, e.g., `myvariable` outside the loop, add the clause `private(myvariable)` to the OpenMP pragma.
 
 Loop trip count `nc` and data arrays `xc` and `yc` can be shared as they are not changed inside the loop. Each thread will access the same data in memory, which is very efficient.
 


### PR DESCRIPTION
Hi @tinyendian and @mand35 ,

Please review the changes:

1. There was some repetition with regards to pragmas and specific fortran comments. In the pro section we don't need to go into that level of details, suffices to say that OpenMP code is portable

2. More importantly we want the example code to be "compilable", students should be able to copy/paste the code and compile/run the code successfully.

3. All compilers I know, including on Mac, now support OpenMP so no need to worry about non-OpenMP compilers. 

4. There is a mistake in the figure "a(i) -> a[i]". @mand35 can you change?

Hope you like my changes.