### PR TITLE
 + paragraph mentioned expected speedup. Minor changes

### DIFF
--- a/_lessons/python-scatter/04a-multiprocessing.md
+++ b/_lessons/python-scatter/04a-multiprocessing.md
@@ -18,7 +18,7 @@ cd multiproc
 
 Multiprocessing is suitable when:
 
- * your computational resources have many CPU cores. On Mahuika, you can access up to 36 cores (72 hyperthreads).
+ * your computational resources have many CPU cores. On Mahuika, you can access up to 36 cores (72 hyperthreads) within a single node.
  * you have a large number of tasks that need to be executed in any order
 
 ### Pros


### PR DESCRIPTION
Hi @chrisdjscott 

I reviewed the multiproc part. Tested the code on mahuika. The most important change is the addition of:
"""
The serial version takes about 50 seconds - there are 5 tasks each taking 10 seconds. The multiprocessing version takes about 20 seconds as some processes need to complete two tasks and others only one. Naturally, it would be more efficient to match the number of tasks to the number of processes. In many cases, however, the number of tasks exceeds the number of processes available on the system, meaning that some processes will need to work on several tasks.
"""
Let me know if you're happy with this PR. If so we can start ticking columns in our table.
