### PR TITLE
 Using sbatch in place of srun

### DIFF
--- a/_lessons/python-scatter/00-introduction.md
+++ b/_lessons/python-scatter/00-introduction.md
@@ -85,16 +85,6 @@ sbatch scatter.sl
 ```
 where you might have to edit `scatter.sl` and add `#SBATCH --account="myAccount"` as well as other options. [See](https://support.nesi.org.nz/hc/en-gb/articles/360000359576-Slurm-Usage-A-Primer) for more information.
 
-### Adjusting the domain size and contour resolution
-
-As you improve the performance of the code, you'll find it useful to increase the problem resolution. This can be done by passing command line options to `scatter.py`. Type `python scatter.py -h` to see the full list of options. The options that control the grid size are `-nx # -ny #` for the number of cells in the x and y direction. Option `-nc #` sets the number of segments. 
-
-The default values are `-nx 128`, `-ny 128` and `-nc 128`. The execution time scales linearly with the values of options `-nx`, `-ny` and `-nc`. For example:
-```
-python scatter.py -nx 256 -ny 256 -nc 512
-```
-will run the code using 256x256 cells and 512 obstacle segments and we expect the code to run `2*2*4 = 16` times longer compared to the default resolution.
-
 
 ### How to check if the results have changed
 
@@ -106,7 +96,7 @@ to record the sum of the field values squared (4686.33935546875). Make sure this
 
 Note: the check sum changes with resolution and other parameters. 
 
-## Measuring execution time
+### Measuring execution time
 
 You can use the `time` command
 ```
@@ -117,3 +107,22 @@ which may return something like
 123.36user 0.14system 2:04.67elapsed 99%CPU (0avgtext+0avgdata 49212maxresident)
 ```
 The relevant time is `elapsed`, the wall clock time. The `time` command will send the output to `stderr` so check your error file when running in batch. 
+
+### Adjusting the domain size and contour resolution to control the execution time
+
+As you modify the code you will find it useful to reduce the problem size in order to quickly check that the output has not changed. Likewise you may find it useful to increase the resolution as you improve the code's performance. 
+
+Changing the problem size can be done by passing command line options to `scatter.py`. Type `python scatter.py -h` to see the full list of options. The options that control the grid size are `-nx # -ny #` for the number of cells in the x and y direction. Option `-nc #` sets the number of segments. 
+
+The default values are `-nx 128`, `-ny 128` and `-nc 128`. The execution time scales linearly with the values of options `-nx`, `-ny` and `-nc`. For example:
+```
+python scatter.py -nx 64 -ny 64 -nc 32
+```
+will run the code using 64x64 cells and 32 obstacle segments. We expect the code to run `2*2*4 = 16` times faster in this case compared to the default resolution.
+
+## Exercises
+
+ * What is the execution time of the default problem resolution (128x128 and 128 segments)?
+ * Modify the scatter.sl script to run with 256x256 and 128 segments. What is the execution time?
+ * How does the larger problem execution time compare with the default resolution execution time?
+

--- a/_lessons/python-scatter/00-introduction.md
+++ b/_lessons/python-scatter/00-introduction.md
@@ -81,9 +81,9 @@ python scatter.py
 ```
 or by submitting a job to the scheduler. On Mahuika
 ```
-srun python scatter.py
+sbatch scatter.sl
 ```
-where you might have to pass `--account="myAccount"` as well as other options to the `srun` command. [See](https://support.nesi.org.nz/hc/en-gb/articles/360000359576-Slurm-Usage-A-Primer) for more information.
+where you might have to edit `scatter.sl` and add `#SBATCH --account="myAccount"` as well as other options. [See](https://support.nesi.org.nz/hc/en-gb/articles/360000359576-Slurm-Usage-A-Primer) for more information.
 
 ### Adjusting the domain size and contour resolution
 
@@ -91,7 +91,7 @@ As you improve the performance of the code, you'll find it useful to increase th
 
 The default values are `-nx 128`, `-ny 128` and `-nc 128`. The execution time scales linearly with the values of options `-nx`, `-ny` and `-nc`. For example:
 ```
-srun python scatter.py -nx 256 -ny 256 -nc 512
+python scatter.py -nx 256 -ny 256 -nc 512
 ```
 will run the code using 256x256 cells and 512 obstacle segments and we expect the code to run `2*2*4 = 16` times longer compared to the default resolution.
 
@@ -100,7 +100,7 @@ will run the code using 256x256 cells and 512 obstacle segments and we expect th
 
 When modifying the code, it is important to check that the results haven't changed. Use
 ```
-srun python scatter.py -c 
+python scatter.py -c 
 ```
 to record the sum of the field values squared (4686.33935546875). Make sure this value does not change after code editing. 
 
@@ -110,10 +110,10 @@ Note: the check sum changes with resolution and other parameters.
 
 You can use the `time` command
 ```
-srun time python scatter.py
+time python scatter.py
 ```
 which may return something like
 ```
 123.36user 0.14system 2:04.67elapsed 99%CPU (0avgtext+0avgdata 49212maxresident)
 ```
-The relevant time is `elapsed`, the wall clock time.
+The relevant time is `elapsed`, the wall clock time. The `time` command will send the output to `stderr` so check your error file when running in batch. 

--- a/_lessons/python-scatter/01-profiling.md
+++ b/_lessons/python-scatter/01-profiling.md
@@ -35,6 +35,6 @@ Due to the possible overhead from profiling tools, the code could run slower tha
 Therefore it is advisable to choose a small but representative test case to profile. That is,
 something that is representative of what you eventually want to run but completes in a short time.
 
-The run time should not be too short, however, as this could make profiling results unreliable. In general, the execution should take at least 10 seconds.
+The run time should not be too short, however, as this could make profiling results unreliable. Depending on the complexity of the code, the execution should take at least 10 seconds.
 
 **Note:** keep in mind that with shortened computation time, the initialisation and finalisation steps may become dominant.

--- a/_lessons/python-scatter/01b-profiling-map.md
+++ b/_lessons/python-scatter/01b-profiling-map.md
@@ -40,20 +40,20 @@ cd mpi
 
 To use MAP we need to load the *forge* module in our batch script and add `map --profile` in front of the executable statements. For example:
 ```
-module load forge
+ml forge
 map --profile srun python scatter.py
 ```
 **Note:** command "map" and its arguments (here `--profile`) must precede "srun" in the case of an MPI program. For serial or OpenMP programs we recommend "map" and its options to be after "srun".
 
 Upon execution, a file with subscript `.map` will be generated. The results can be viewed, for instance, with
 ```
-map python3_scatter_py_8p_1n_2019-01-14_00-31.map
+map python3_scatter_py_4p_1n_1t_2019-05-22_00-58.map
 ```
 (the `.map` file name will vary with each run.) See section [MAP Profile](#map-profile) for how to interpret the results.
 
 ## Using the graphical interface
 
-The GUI can be started after loading `module load forge` and launching
+The GUI can be started after loading `ml forge` and launching
 ```
 map
 ```

--- a/_lessons/python-scatter/02-vectorising.md
+++ b/_lessons/python-scatter/02-vectorising.md
@@ -110,6 +110,6 @@ where `dsdt`, `g`, etc. are all arrays of size `n - 1` (number of segments).
 
  1. profile the vectorised code and compare to the non-vectorised code
 
- 2. in scatter.py, vectorise function `isInsideContour` by eliminating the loop computing the sum `tot` and report the new timing
+ 2. in scatter.py, vectorise function `isInsideContour` by eliminating the loop computing the boolean variable `inside` and report the new timing
  
 

--- a/_lessons/python-scatter/04a-multiprocessing.md
+++ b/_lessons/python-scatter/04a-multiprocessing.md
@@ -75,16 +75,11 @@ The serial version takes about 50 seconds - there are 5 tasks each taking 10 sec
 
 ## Running the scatter code using multiple threads
 
-We've created a version of `scatter.py` which reads the environment variable `OMP_NUM_THREADS` to set the number of processes. To submit a job with 8 processes on Mahuika, type
-```
-srun --hint=nomultithread --ntasks=1 --cpus-per-task=8 \
-time python scatter.py -checksum
-```
-(with additional `srun` options such as `--account=` required). Option `--hint=nomultithread` ensures that each physical core gets only one process, recommended in most cases for best performance. Without this option two processes may be placed on each core.
+We've created a version of `scatter.py` which reads the environment variable `OMP_NUM_THREADS` to set the number of processes. We've also modified our `scatter.sl` script to set the number of processes using `--cpus-per-task=4`. To prevent two processes to be placed on each core, we use `--hint=nomultithread`. 
 
-To run interactively using 8 processes, type
+To run interactively using 4 processes, type
 ```
-export OMP_NUM_THREADS=8
+export OMP_NUM_THREADS=4
 python scatter.py
 ```
 


### PR DESCRIPTION
We decided that we will use sbatch scripts instead of the srun commands. Modified the material by replacing all occurrences of "srun ..." by "sbatch scatter.sl". The scatter.sl scripts have been committed to the scatter repo. 